### PR TITLE
[FEAT] 카페 상세 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/keotam/cafe/domain/Brand.java
+++ b/backend/src/main/java/com/keotam/cafe/domain/Brand.java
@@ -1,0 +1,45 @@
+package com.keotam.cafe.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Brand {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "brand_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "brand" , cascade = CascadeType.ALL)
+    private List<BrandMenu> menus = new ArrayList<>();
+
+    @Builder
+    public Brand(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    @Builder
+    public Brand(Long id, String name, List<BrandMenu> menus) {
+        this.id = id;
+        this.name = name;
+        this.menus = menus;
+    }
+
+    public void addMenu(BrandMenu menu) {
+        menus.add(menu);
+        menu.setBrand(this); // 연관관계 주인도 설정
+    }
+}

--- a/backend/src/main/java/com/keotam/cafe/domain/BrandMenu.java
+++ b/backend/src/main/java/com/keotam/cafe/domain/BrandMenu.java
@@ -1,0 +1,39 @@
+package com.keotam.cafe.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BrandMenu {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "brand_menu_id")
+    private Long id;
+
+    private String name;
+
+    private Integer price;
+
+    private MenuCategory category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "brand_id")
+    private Brand brand;
+
+    @Builder
+    public BrandMenu(Long id, String name, Integer price, MenuCategory category) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.category = category;
+    }
+
+    public void setBrand(Brand brand) {
+        this.brand = brand;
+    }
+}

--- a/backend/src/main/java/com/keotam/cafe/domain/Cafe.java
+++ b/backend/src/main/java/com/keotam/cafe/domain/Cafe.java
@@ -31,13 +31,18 @@ public class Cafe {
     @Column(columnDefinition = "geometry(Point,4326)")
     private Point location;
 
+    @ManyToOne
+    @JoinColumn(name="brand_id")
+    private Brand brand;
+
     @Builder
-    public Cafe(Long id, String name, String address, Double latitude, Double longitude, Point location) {
+    public Cafe(Long id, String name, String address, Double latitude, Double longitude, Point location, Brand brand) {
         this.id = id;
         this.name = name;
         this.address = address;
         this.latitude = latitude;
         this.longitude = longitude;
         this.location = location;
+        this.brand = brand;
     }
 }

--- a/backend/src/main/java/com/keotam/cafe/domain/MenuCategory.java
+++ b/backend/src/main/java/com/keotam/cafe/domain/MenuCategory.java
@@ -1,0 +1,5 @@
+package com.keotam.cafe.domain;
+
+public enum MenuCategory {
+    COFFEE, NON_COFFEE,TEA,ADE,FRAPPE,DESSERT,ETC
+}

--- a/backend/src/main/java/com/keotam/cafe/domain/repository/BrandMenuRepository.java
+++ b/backend/src/main/java/com/keotam/cafe/domain/repository/BrandMenuRepository.java
@@ -1,0 +1,9 @@
+package com.keotam.cafe.domain.repository;
+
+import com.keotam.cafe.domain.BrandMenu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BrandMenuRepository extends JpaRepository<BrandMenu, Long> {
+}

--- a/backend/src/main/java/com/keotam/cafe/domain/repository/BrandRepository.java
+++ b/backend/src/main/java/com/keotam/cafe/domain/repository/BrandRepository.java
@@ -1,0 +1,9 @@
+package com.keotam.cafe.domain.repository;
+
+import com.keotam.cafe.domain.Brand;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BrandRepository extends JpaRepository<Brand, Long> {
+}

--- a/backend/src/main/java/com/keotam/cafe/domain/repository/CafeRepositoryCustom.java
+++ b/backend/src/main/java/com/keotam/cafe/domain/repository/CafeRepositoryCustom.java
@@ -4,7 +4,8 @@ import com.keotam.cafe.domain.Cafe;
 import com.keotam.cafe.dto.request.CafeSearchRequest;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CafeRepositoryCustom {
-//    List<Cafe> searchCafes(CafeSearchRequest cafeSearchRequest);
+    public Optional<Cafe> findByIdWithBrandAndMenus(Long cafeId);
 }

--- a/backend/src/main/java/com/keotam/cafe/domain/repository/CafeRepositoryImpl.java
+++ b/backend/src/main/java/com/keotam/cafe/domain/repository/CafeRepositoryImpl.java
@@ -1,46 +1,25 @@
 package com.keotam.cafe.domain.repository;
 
 import com.keotam.cafe.domain.Cafe;
-import com.keotam.cafe.domain.QCafe;
-import com.keotam.cafe.dto.request.CafeSearchRequest;
-import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import java.util.Optional;
 
-import java.util.List;
+import static com.keotam.cafe.domain.QBrand.*;
+import static com.keotam.cafe.domain.QBrandMenu.*;
+import static com.keotam.cafe.domain.QCafe.*;
 
 @RequiredArgsConstructor
 public class CafeRepositoryImpl implements CafeRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
-    public List<Cafe> searchCafes(CafeSearchRequest cafeSearchRequest) {
-        QCafe cafe = QCafe.cafe;
-        BooleanBuilder builder = new BooleanBuilder();
-
-        if(cafeSearchRequest.getKeyword() != null && !cafeSearchRequest.getKeyword().isEmpty()) {
-            builder.and(cafe.name.containsIgnoreCase(cafeSearchRequest.getKeyword()));
-        }
-
-        Pageable pageable = PageRequest.of(cafeSearchRequest.getPage(), cafeSearchRequest.getSize());
-
-        return queryFactory.selectFrom(cafe)
-                .where(builder)
-                .orderBy(
-                        Expressions.numberTemplate(Double.class,
-                                "ST_DistanceSphere(" +
-                                        "ST_MakePoint(cast({0} as double precision), cast({1} as double precision)), " +
-                                        "ST_MakePoint(cast({2} as double precision), cast({3} as double precision))" +
-                                        ")",
-                                cafeSearchRequest.getLongitude(), cafeSearchRequest.getLatitude(),
-                                cafe.longitude, cafe.latitude
-                        ).asc()
-                )
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+    @Override
+    public Optional<Cafe> findByIdWithBrandAndMenus(Long cafeId) {
+        return Optional.ofNullable(queryFactory.selectFrom(cafe)
+                .join(cafe.brand, brand).fetchJoin()
+                .join(brand.menus, brandMenu).fetchJoin()
+                .where(cafe.id.eq(cafeId))
+                .distinct()
+                .fetchOne());
     }
 }

--- a/backend/src/main/java/com/keotam/cafe/dto/response/CafeDetailResponse.java
+++ b/backend/src/main/java/com/keotam/cafe/dto/response/CafeDetailResponse.java
@@ -1,0 +1,18 @@
+package com.keotam.cafe.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CafeDetailResponse {
+    private String category;
+    private List<MenuResponse> menus;
+
+    @Builder
+    public CafeDetailResponse(String category, List<MenuResponse> menus) {
+        this.category = category;
+        this.menus = menus;
+    }
+}

--- a/backend/src/main/java/com/keotam/cafe/dto/response/MenuResponse.java
+++ b/backend/src/main/java/com/keotam/cafe/dto/response/MenuResponse.java
@@ -1,0 +1,29 @@
+package com.keotam.cafe.dto.response;
+
+import com.keotam.cafe.domain.BrandMenu;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MenuResponse {
+    private String name;
+    private Integer price;
+    private String brand;
+    private String category;
+    @Builder
+    public MenuResponse(String name, Integer price, String brand, String category) {
+        this.name = name;
+        this.price = price;
+        this.brand = brand;
+        this.category = category;
+    }
+
+    public static MenuResponse fromEntity(BrandMenu menu){
+        return MenuResponse.builder()
+                .brand(menu.getBrand().getName())
+                .name(menu.getName())
+                .category(menu.getCategory().toString())
+                .price(menu.getPrice())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/keotam/cafe/exception/CafeDetailNotFound.java
+++ b/backend/src/main/java/com/keotam/cafe/exception/CafeDetailNotFound.java
@@ -1,0 +1,16 @@
+package com.keotam.cafe.exception;
+
+import com.keotam.global.exception.KeotamException;
+
+public class CafeDetailNotFound extends KeotamException {
+    private final static String MESSAGE = "카페에 대한 세부 항목이 없습니다.";
+
+    public CafeDetailNotFound() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 404;
+    }
+}

--- a/backend/src/main/java/com/keotam/cafe/presentation/CafeController.java
+++ b/backend/src/main/java/com/keotam/cafe/presentation/CafeController.java
@@ -1,15 +1,18 @@
 package com.keotam.cafe.presentation;
 
 import com.keotam.cafe.dto.request.CafeSearchRequest;
+import com.keotam.cafe.dto.response.CafeDetailResponse;
 import com.keotam.cafe.dto.response.CafeSearchResponse;
 import com.keotam.cafe.service.CafeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController()
 @RequestMapping("/cafe") // ✅ 여기에 base path 설정
@@ -22,5 +25,11 @@ public class CafeController {
         List<CafeSearchResponse> cafeSearchResponses = cafeService.searchCafes(request);
 
         return ResponseEntity.ok(cafeSearchResponses);
+    }
+
+    @GetMapping("/{cafeId}")
+    public ResponseEntity<List<CafeDetailResponse>> getCafeDetails(@PathVariable("cafeId") Long cafeId) {
+        List<CafeDetailResponse> cafeDetail = cafeService.getCafeDetail(cafeId);
+        return ResponseEntity.ok(cafeDetail);
     }
 }

--- a/backend/src/main/java/com/keotam/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/keotam/global/config/SecurityConfig.java
@@ -16,7 +16,10 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests((authorizeRequests) -> authorizeRequests.anyRequest().permitAll());
+                .authorizeHttpRequests((authorizeRequests) -> authorizeRequests
+                        .requestMatchers("/h2-console/**", "/swagger-ui/**", "/health", "/v3/api-docs", "/swagger/**","/actuator/**").permitAll()
+                        .anyRequest().permitAll()
+                );
         return http.build();
     }
 }

--- a/backend/src/test/java/com/keotam/cafe/domain/repository/CafeRepositoryImplTest.java
+++ b/backend/src/test/java/com/keotam/cafe/domain/repository/CafeRepositoryImplTest.java
@@ -1,0 +1,73 @@
+package com.keotam.cafe.domain.repository;
+
+import com.keotam.cafe.domain.Brand;
+import com.keotam.cafe.domain.BrandMenu;
+import com.keotam.cafe.domain.Cafe;
+import com.keotam.cafe.domain.MenuCategory;
+import com.keotam.cafe.exception.CafeDetailNotFound;
+import com.keotam.global.config.QueryDslConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+class CafeRepositoryImplTest {
+    @Autowired
+    private CafeRepository cafeRepository;
+    @Autowired
+    private BrandMenuRepository brandMenuRepository;
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Test
+    @DisplayName("카페 ID로 브랜드와 브랜드 고정 메뉴까지 조회가 가능하다.")
+    void findByIdWithBrandAndMenusSuccess() throws Exception {
+        //given
+        BrandMenu menu1 = BrandMenu.builder()
+                .name("아메리카노")
+                .category(MenuCategory.COFFEE)
+                .price(2000)
+                .build();
+        BrandMenu menu2 = BrandMenu.builder()
+                .name("말차라떼")
+                .category(MenuCategory.NON_COFFEE)
+                .price(5000)
+                .build();
+        brandMenuRepository.saveAll(Arrays.asList(menu1,menu2));
+
+        Brand brand = Brand.builder()
+                .name("컴포즈")
+                .build();
+
+        brand.addMenu(menu1);
+        brand.addMenu(menu2);
+        brandRepository.save(brand);
+
+        Cafe cafe = Cafe.builder()
+                .name("컴포즈")
+                .address("창원시")
+                .longitude(123.0)
+                .latitude(123.0)
+                .brand(brand)
+                .build();
+        cafeRepository.save(cafe);
+        //when
+        Cafe result = cafeRepository.findByIdWithBrandAndMenus(cafe.getId())
+                .orElseThrow(CafeDetailNotFound::new);
+        //then
+        assertEquals(result.getBrand().getName(),"컴포즈");
+        assertEquals(result.getBrand().getMenus().size(),2);
+        assertEquals(result.getBrand().getMenus().get(0).getCategory(),MenuCategory.COFFEE);
+        assertEquals(result.getBrand().getMenus().get(1).getName(),"말차라떼");
+    }
+}

--- a/backend/src/test/java/com/keotam/cafe/presentation/CafeControllerTest.java
+++ b/backend/src/test/java/com/keotam/cafe/presentation/CafeControllerTest.java
@@ -2,7 +2,9 @@ package com.keotam.cafe.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.keotam.cafe.dto.request.CafeSearchRequest;
+import com.keotam.cafe.dto.response.CafeDetailResponse;
 import com.keotam.cafe.dto.response.CafeSearchResponse;
+import com.keotam.cafe.dto.response.MenuResponse;
 import com.keotam.cafe.service.CafeService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,8 +21,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(CafeController.class)
@@ -62,5 +63,52 @@ class CafeControllerTest {
                 .andExpect(jsonPath("$.size()").value(10))
                 .andExpect(jsonPath("$[0].name").value("카페 1"))
                 .andExpect(jsonPath("$[0].distance").value(10.0));
+    }
+
+    @Test
+    @DisplayName("카페ID로 카페 상세 조회시 카페에 대한 브랜드이름과 카페 메뉴 정보가 200응답으로 내려온다")
+    void getCafeDetail200Success() throws Exception {
+        //given
+        List<MenuResponse> coffeeMenus = List.of(
+                MenuResponse.builder()
+                        .name("아메리카노")
+                        .price(2000)
+                        .brand("컴포즈")
+                        .category("COFFEE")
+                        .build(),
+                MenuResponse.builder()
+                        .name("카페라떼")
+                        .price(3000)
+                        .brand("컴포즈")
+                        .category("COFFEE")
+                        .build()
+        );
+
+        List<MenuResponse> nonCoffeeMenus = List.of(
+                MenuResponse.builder()
+                        .name("말차라떼")
+                        .price(5000)
+                        .brand("컴포즈")
+                        .category("NON_COFFEE")
+                        .build()
+        );
+
+        List<CafeDetailResponse> mockedResponse = List.of(
+                CafeDetailResponse.builder()
+                        .category("COFFEE")
+                        .menus(coffeeMenus)
+                        .build(),
+                CafeDetailResponse.builder()
+                        .category("NON_COFFEE")
+                        .menus(nonCoffeeMenus)
+                        .build()
+        );
+        String expectResult = objectMapper.writeValueAsString(mockedResponse);
+        given(cafeService.getCafeDetail(any(Long.class))).willReturn(mockedResponse);
+        //expect
+        mockMvc.perform(get("/cafe/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectResult));
+
     }
 }

--- a/backend/src/test/java/com/keotam/cafe/service/CafeServiceTest.java
+++ b/backend/src/test/java/com/keotam/cafe/service/CafeServiceTest.java
@@ -1,8 +1,16 @@
 package com.keotam.cafe.service;
 
+import com.keotam.cafe.domain.Brand;
+import com.keotam.cafe.domain.BrandMenu;
+import com.keotam.cafe.domain.Cafe;
+import com.keotam.cafe.domain.MenuCategory;
+import com.keotam.cafe.domain.repository.BrandMenuRepository;
+import com.keotam.cafe.domain.repository.BrandRepository;
 import com.keotam.cafe.domain.repository.CafeRepository;
 import com.keotam.cafe.dto.request.CafeSearchRequest;
+import com.keotam.cafe.dto.response.CafeDetailResponse;
 import com.keotam.cafe.dto.response.CafeSearchResponse;
+import com.keotam.cafe.dto.response.MenuResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,9 +22,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,6 +38,12 @@ class CafeServiceTest {
 
     @InjectMocks
     private CafeService cafeService;
+
+    @Mock
+    private BrandRepository brandRepository;
+
+    @Mock
+    private BrandMenuRepository brandMenuRepository;
 
     @Test
     @DisplayName("첫페이지 조회 요청 시 현재 위치 기준 가까운 카페가 정렬되어 조회된다.")
@@ -101,5 +119,63 @@ class CafeServiceTest {
         assertEquals(1, result.size());
         assertEquals(result.get(0).getName(),"카페 5");
         assertEquals(result.get(0).getDistance(),250.0);
+    }
+
+    @Test
+    @DisplayName("카페 ID로 카페 메뉴 조회시 카테고리별로 그룹화 된 정보로 조회된다.")
+    void getCafeMenus() throws Exception {
+        //given
+        BrandMenu menu1 = BrandMenu.builder()
+                .name("아메리카노")
+                .category(MenuCategory.COFFEE)
+                .price(2000)
+                .build();
+        BrandMenu menu2 = BrandMenu.builder()
+                .name("말차라떼")
+                .category(MenuCategory.NON_COFFEE)
+                .price(5000)
+                .build();
+        BrandMenu menu3 = BrandMenu.builder()
+                .name("카페라떼")
+                .category(MenuCategory.COFFEE)
+                .price(3000)
+                .build();
+
+        Brand brand = Brand.builder()
+                .name("컴포즈")
+                .build();
+        brand.addMenu(menu1);
+        brand.addMenu(menu2);
+        brand.addMenu(menu3);
+
+        Cafe cafe = Cafe.builder()
+                .name("컴포즈")
+                .address("창원시")
+                .longitude(123.0)
+                .latitude(123.0)
+                .brand(brand)
+                .build();
+
+        given(cafeRepository.findByIdWithBrandAndMenus(any(Long.class)))
+                .willReturn(Optional.ofNullable(cafe));
+
+        //when
+        List<CafeDetailResponse> cafeDetailResponses = cafeService.getCafeDetail(1L);
+
+        //then
+        assertEquals(cafeDetailResponses.size(),2);
+        assertEquals(cafeDetailResponses.get(0).getMenus().size(),2);
+        assertEquals(cafeDetailResponses.get(0).getMenus().get(0).getBrand(),"컴포즈");
+        
+        assertEquals(cafeDetailResponses.get(0).getCategory(),"COFFEE");
+        assertEquals(cafeDetailResponses.get(0).getMenus().get(0).getPrice(),2000);
+        assertEquals(cafeDetailResponses.get(0).getMenus().get(0).getName(),"아메리카노");
+        assertEquals(cafeDetailResponses.get(0).getMenus().get(1).getPrice(),3000);
+        assertEquals(cafeDetailResponses.get(0).getMenus().get(1).getName(),"카페라떼");
+
+
+        assertEquals(cafeDetailResponses.get(1).getCategory(),"NON_COFFEE");
+        assertEquals(cafeDetailResponses.get(1).getMenus().get(0).getPrice(),5000);
+        assertEquals(cafeDetailResponses.get(1).getMenus().get(0).getName(),"말차라떼");
     }
 }


### PR DESCRIPTION
### 구현 내용
- 카페 상세 조회 리포지토리 구현(fetch join 활용)
- 카페 상세 조회 서비스 로직 구현
- 카페 상세 조회 컨트롤러 구현

### 테스트 결과
전체 테스트 통과

### 이슈
카페 상세 조회시 카페 메뉴 카테고리별 필터링 기능 구현 시 서버에서 처리하는지 프론트에서 처리하는지 고려
프론트에서도 결국 카테고리별로 그룹핑하는 것이 필요함으로 그룹화 및 가격으로 Order By 후 반환