### PR TITLE
[FEAT] 사용자 투표 참여를 위한 페이지 조회 관련 기능 구현

### DIFF
--- a/backend/src/main/java/com/keotam/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/keotam/global/config/SecurityConfig.java
@@ -1,17 +1,27 @@
 package com.keotam.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keotam.global.security.vote.VoterAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final VoterAuthenticationFilter voterAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -19,17 +29,26 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .headers(header -> header.frameOptions((frame-> frame.disable())))
                 .authorizeHttpRequests((authorizeRequests) -> authorizeRequests
                         .requestMatchers("/h2-console/**", "/swagger-ui/**", "/health", "/v3/api-docs", "/swagger/**","/actuator/**").permitAll()
-                        .requestMatchers("/votes/**","/cafes/**").permitAll()
-                        .anyRequest().permitAll()
-                );
+                        .requestMatchers("/cafe/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/votes").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/votes/*/voters").permitAll()
+                        .requestMatchers("/votes/**").authenticated()
+                )
+                .addFilterBefore(voterAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public ObjectMapper objectMapper(){
+        return new ObjectMapper();
     }
 }

--- a/backend/src/main/java/com/keotam/global/security/vote/VoterAuthenticationFilter.java
+++ b/backend/src/main/java/com/keotam/global/security/vote/VoterAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.keotam.global.security.vote;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.keotam.global.exception.ErrorResponse;
+import com.keotam.global.exception.KeotamException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class VoterAuthenticationFilter extends OncePerRequestFilter {
+    private final VoterAuthenticationProvider authenticationProvider;
+    private static final String VOTER_UUID_HEADER = "Voter-UUID";
+    private final ObjectMapper objectMapper = new ObjectMapper(); // 직접 생성
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String voterUuid = request.getHeader(VOTER_UUID_HEADER);
+        if (StringUtils.hasText(voterUuid)) {        // UUID가 있으면
+            try {
+                VoterAuthenticationToken authToken = new VoterAuthenticationToken(voterUuid);
+                Authentication authentication = authenticationProvider.authenticate(authToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.debug("투표자 인증 성공 투표자 UUID : {}",voterUuid);
+            } catch (KeotamException ex) {
+                sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "VOTER_NOT_FOUND",
+                        "신규 참여자 등록 후 투표 진행이 필요합니다.");
+                return;
+            } catch (Exception e) {
+                log.error("Error during voter authentication: ", e);
+                sendErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_ERROR",
+                        "서비스 문제로 현재 투표 이용이 실패했습니다.");
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, HttpStatus status, String errorCode, String message)
+            throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        // 기존 ErrorResponse 형태에 맞춰서 응답
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code(errorCode)
+                .message(message)
+                .build();
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/backend/src/main/java/com/keotam/global/security/vote/VoterAuthenticationProvider.java
+++ b/backend/src/main/java/com/keotam/global/security/vote/VoterAuthenticationProvider.java
@@ -1,0 +1,38 @@
+package com.keotam.global.security.vote;
+
+import com.keotam.vote.domain.Voter;
+import com.keotam.vote.domain.repository.VoterRepository;
+import com.keotam.vote.exception.VoterNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class VoterAuthenticationProvider implements AuthenticationProvider {
+    private final VoterRepository voterRepository;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        VoterAuthenticationToken token = (VoterAuthenticationToken) authentication;
+        String voterUuid = token.getVoterUuid();
+
+        Voter voter = voterRepository.findByVoterUuid(voterUuid)
+                .orElseThrow(VoterNotFoundException::new);
+
+        VoterPrincipal voterPrincipal = VoterPrincipal.builder()
+                .voterUuid(voterUuid)
+                .voterName(voter.getVoterName())
+                .voterType(voter.getVoterType())
+                .build();
+
+        return new VoterAuthenticationToken(voterPrincipal,voterPrincipal.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return VoterAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/backend/src/main/java/com/keotam/global/security/vote/VoterAuthenticationToken.java
+++ b/backend/src/main/java/com/keotam/global/security/vote/VoterAuthenticationToken.java
@@ -1,0 +1,39 @@
+package com.keotam.global.security.vote;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class VoterAuthenticationToken extends AbstractAuthenticationToken {
+    private final String voterUuid;
+    private final VoterPrincipal principal;
+
+    public VoterAuthenticationToken(String voterUuid) {
+        super(null);
+        this.voterUuid = voterUuid;
+        this.principal = null;
+        setAuthenticated(false);
+    }
+
+    public VoterAuthenticationToken(VoterPrincipal principal, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.voterUuid = principal.getVoterUuid();
+        this.principal = principal;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+
+    public String getVoterUuid() {
+        return voterUuid;
+    }
+}

--- a/backend/src/main/java/com/keotam/global/security/vote/VoterPrincipal.java
+++ b/backend/src/main/java/com/keotam/global/security/vote/VoterPrincipal.java
@@ -1,0 +1,40 @@
+package com.keotam.global.security.vote;
+
+import com.keotam.vote.domain.VoterType;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+public class VoterPrincipal implements UserDetails {
+    private final String voterUuid;
+    private final String voterName;
+    private final VoterType voterType;
+
+    @Builder
+    public VoterPrincipal(String voterUuid, String voterName, VoterType voterType) {
+        this.voterUuid = voterUuid;
+        this.voterName = voterName;
+        this.voterType = voterType;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + voterType.name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return voterUuid;
+    }
+}

--- a/backend/src/main/java/com/keotam/vote/domain/repository/VoterRepository.java
+++ b/backend/src/main/java/com/keotam/vote/domain/repository/VoterRepository.java
@@ -4,6 +4,9 @@ import com.keotam.vote.domain.Voter;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface VoterRepository extends JpaRepository<Voter, Long> {
+    Optional<Voter> findByVoterUuid(String voterUuid);
 }

--- a/backend/src/main/java/com/keotam/vote/presentation/VoteController.java
+++ b/backend/src/main/java/com/keotam/vote/presentation/VoteController.java
@@ -30,4 +30,10 @@ public class VoteController {
                 .body(votePageResponse);
     }
 
+    @GetMapping("/votes/{shareUuid}")
+    public ResponseEntity<VotePageResponse> getVote(@PathVariable String shareUuid) {
+        VotePageResponse votePageResponse = voteService.getVote(shareUuid);
+        return ResponseEntity.ok(votePageResponse);
+    }
+
 }

--- a/backend/src/test/java/com/keotam/cafe/presentation/CafeControllerTest.java
+++ b/backend/src/test/java/com/keotam/cafe/presentation/CafeControllerTest.java
@@ -6,25 +6,25 @@ import com.keotam.cafe.dto.response.CafeDetailResponse;
 import com.keotam.cafe.dto.response.CafeSearchResponse;
 import com.keotam.cafe.dto.response.MenuResponse;
 import com.keotam.cafe.service.CafeService;
+import com.keotam.global.config.SecurityConfig;
+import com.keotam.global.security.vote.VoterAuthenticationProvider;
+import com.keotam.vote.domain.repository.VoterRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-
 import java.util.List;
 import java.util.stream.IntStream;
-
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(CafeController.class)
+@Import(SecurityConfig.class)
 class CafeControllerTest {
     @Autowired
     private MockMvc mockMvc;
@@ -34,6 +34,12 @@ class CafeControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private VoterRepository voterRepository;
+
+    @MockitoBean
+    private VoterAuthenticationProvider voterAuthenticationProvider;
 
     @Test
     @DisplayName("검색어와 위치정보가 포함된 카페 조회 요청 시 카페 리스트가 반환됩니다. 200응답과 함꼐")

--- a/backend/src/test/java/com/keotam/global/security/vote/VoterAuthenticationFilterTest.java
+++ b/backend/src/test/java/com/keotam/global/security/vote/VoterAuthenticationFilterTest.java
@@ -1,0 +1,107 @@
+package com.keotam.global.security.vote;
+
+import com.keotam.vote.domain.VoterType;
+import com.keotam.vote.exception.VoterNotFoundException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.PrintWriter;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VoterAuthenticationFilterTest {
+    @Mock
+    private VoterAuthenticationProvider provider;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    @Mock
+    private PrintWriter writer;
+
+    @InjectMocks
+    private VoterAuthenticationFilter filter;
+
+    @Test
+    @DisplayName("요청 헤더에 VoterUUID가 없으면 필터체인이 안넘어간다.")
+    void whenVoterDoesntHaveVoterUuidPassFilterChain() throws Exception {
+        //given
+        when(request.getHeader("Voter-UUID"))
+                .thenReturn(null);
+        //when
+        filter.doFilterInternal(request, response, chain);
+        //then
+        verify(chain).doFilter(request, response);
+        verify(provider, never()).authenticate(any());
+    }
+
+    @Test
+    @DisplayName("유효한 Voter-UUID가 있으면 인증이 성공한다.")
+    void whenValidVoterUuidSuccessAuthentication() throws Exception {
+        //given
+        String voterUuid = "voterUuid";
+        when(request.getHeader("Voter-UUID"))
+                .thenReturn(voterUuid);
+
+        VoterPrincipal principal = VoterPrincipal.builder()
+                .voterUuid(voterUuid)
+                .voterName("김참여")
+                .voterType(VoterType.INVITED)
+                .build();
+
+        VoterAuthenticationToken authenticationToken = new VoterAuthenticationToken(principal,principal.getAuthorities());
+        when(provider.authenticate(any()))
+                .thenReturn(authenticationToken);
+        //when
+        filter.doFilterInternal(request, response, chain);
+        //then
+        verify(chain).doFilter(request, response);
+        verify(provider).authenticate(any(VoterAuthenticationToken.class));
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth);
+        assertTrue(auth.isAuthenticated());
+        assertTrue(auth.getPrincipal() instanceof VoterPrincipal);
+    }
+
+    @Test
+    @DisplayName("Voter가 존재하지 않으면 401로 응답이 온다")
+    void whenVoterNotFoundExceptionReturn401Response() throws Exception {
+        //given
+        String voterUuid = "notVoter";
+        when(request.getHeader("Voter-UUID"))
+                .thenReturn(voterUuid);
+        when(response.getWriter()).thenReturn(writer);
+        when(provider.authenticate(any()))
+                .thenThrow(new VoterNotFoundException());
+
+        //when
+        filter.doFilterInternal(request, response, chain);
+
+        //then
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(response).setContentType("application/json");
+        verify(chain,never()).doFilter(request, response);
+    }
+}

--- a/backend/src/test/java/com/keotam/global/security/vote/VoterAuthenticationProviderTest.java
+++ b/backend/src/test/java/com/keotam/global/security/vote/VoterAuthenticationProviderTest.java
@@ -1,0 +1,62 @@
+package com.keotam.global.security.vote;
+
+import com.keotam.vote.domain.Voter;
+import com.keotam.vote.domain.VoterType;
+import com.keotam.vote.domain.repository.VoterRepository;
+import com.keotam.vote.exception.VoterNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VoterAuthenticationProviderTest {
+    @Mock
+    private VoterRepository voterRepository;
+
+    @InjectMocks
+    private VoterAuthenticationProvider provider;
+
+    @Test
+    @DisplayName("VoterUuid가 있는 참여자이면 인증 객체를 반환한다.")
+    void whenValidVoterUuidReturnAuthentication() throws Exception {
+        //given
+        String voterUuid = "voterUuid";
+        Voter voter = Voter.builder()
+                .voterUuid(voterUuid)
+                .voterName("김참여")
+                .voterType(VoterType.INVITED)
+                .build();
+        when(voterRepository.findByVoterUuid(voterUuid)).thenReturn(Optional.of(voter));
+        VoterAuthenticationToken token = new VoterAuthenticationToken(voterUuid);
+        //when
+        Authentication result = provider.authenticate(token);
+
+        //then
+        assertNotNull(result);
+        assertTrue(result.isAuthenticated());
+        VoterPrincipal principal = (VoterPrincipal) result.getPrincipal();
+        assertEquals(voterUuid, principal.getVoterUuid());
+        assertEquals(voter.getVoterName(), principal.getVoterName());
+    }
+
+    @Test
+    @DisplayName("만약 참여하지 않은 사람이 참여 시 VoterNotFound 예외 발생")
+    void whenInValidVoterUuidThrowException() throws Exception {
+        //given
+        String voterUuid = "InvalidVoterUuid";
+        when(voterRepository.findByVoterUuid(voterUuid)).thenReturn(Optional.empty());
+
+        //when
+        assertThrows(VoterNotFoundException.class, () -> provider.authenticate(new VoterAuthenticationToken(voterUuid)));
+        //then
+    }
+}

--- a/backend/src/test/java/com/keotam/vote/presentation/VoteControllerTest.java
+++ b/backend/src/test/java/com/keotam/vote/presentation/VoteControllerTest.java
@@ -8,6 +8,7 @@ import com.keotam.cafe.domain.MenuCategory;
 import com.keotam.cafe.dto.response.CafeDetailResponse;
 import com.keotam.cafe.dto.response.MenuResponse;
 import com.keotam.global.config.SecurityConfig;
+import com.keotam.global.exception.KeotamException;
 import com.keotam.global.security.vote.VoterAuthenticationProvider;
 import com.keotam.global.security.vote.VoterAuthenticationToken;
 import com.keotam.global.security.vote.VoterPrincipal;
@@ -17,6 +18,7 @@ import com.keotam.vote.dto.request.VoteCreateRequest;
 import com.keotam.vote.dto.request.VoterCreateRequest;
 import com.keotam.vote.dto.response.VoteCreateResponse;
 import com.keotam.vote.dto.response.VotePageResponse;
+import com.keotam.vote.exception.VoterNotFoundException;
 import com.keotam.vote.service.VoteService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,11 +31,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -244,5 +248,21 @@ class VoteControllerTest {
                 .andExpect(jsonPath("$.cafeDetailResponse[0].menus[0]").exists());
         //then
 
+    }
+
+    @Test
+    @DisplayName("재투표를 위해서 투표 조회 요청 시 투표 페이지 정보를 반환한다.")
+    void whenVoterUuidIsInvalidsThrowException() throws Exception {
+        //given
+        String shareUuid = "shareUuid";
+        String voterUuid = "invalidVoterUuid";
+
+        given(voterAuthenticationProvider.authenticate(any(VoterAuthenticationToken.class)))
+                .willThrow(new VoterNotFoundException());
+
+        //when
+        mockMvc.perform(get("/votes/"+shareUuid)
+                        .header("Voter-UUID",voterUuid))
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/backend/src/test/java/com/keotam/vote/presentation/VoteControllerTest.java
+++ b/backend/src/test/java/com/keotam/vote/presentation/VoteControllerTest.java
@@ -8,6 +8,11 @@ import com.keotam.cafe.domain.MenuCategory;
 import com.keotam.cafe.dto.response.CafeDetailResponse;
 import com.keotam.cafe.dto.response.MenuResponse;
 import com.keotam.global.config.SecurityConfig;
+import com.keotam.global.security.vote.VoterAuthenticationProvider;
+import com.keotam.global.security.vote.VoterAuthenticationToken;
+import com.keotam.global.security.vote.VoterPrincipal;
+import com.keotam.vote.domain.VoterType;
+import com.keotam.vote.domain.repository.VoterRepository;
 import com.keotam.vote.dto.request.VoteCreateRequest;
 import com.keotam.vote.dto.request.VoterCreateRequest;
 import com.keotam.vote.dto.response.VoteCreateResponse;
@@ -21,17 +26,15 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -46,6 +49,12 @@ class VoteControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private VoterRepository voterRepository;
+
+    @MockitoBean
+    private VoterAuthenticationProvider voterAuthenticationProvider;
 
     @Test
     @DisplayName("")
@@ -153,8 +162,87 @@ class VoteControllerTest {
                 .andExpect(jsonPath("$.cafeDetailResponse", hasSize(greaterThan(0))))
                 .andExpect(jsonPath("$.cafeDetailResponse[0].category").exists())
                 .andExpect(jsonPath("$.cafeDetailResponse[0].menus[0]").exists());
+    }
 
-        //TODO 투표 페이지 응답 객체 반환 시 메뉴에 대한 ID도 함께 반환해줘야한다.
-        //TODO 내일 관련 로직 수정 하고 테스트 코드 추가 필요
+    @Test
+    @DisplayName("재투표를 위해서 투표 조회 요청 시 투표 페이지 정보를 반환한다.")
+    void whenGetRequestSuccessReturnVotePageResponse() throws Exception {
+        //given
+        String shareUuid = "shareUuid";
+
+        BrandMenu menu1 = BrandMenu.builder()
+                .name("아메리카노")
+                .category(MenuCategory.COFFEE)
+                .price(2000)
+                .build();
+        BrandMenu menu2 = BrandMenu.builder()
+                .name("말차라떼")
+                .category(MenuCategory.NON_COFFEE)
+                .price(5000)
+                .build();
+        BrandMenu menu3 = BrandMenu.builder()
+                .name("카페라떼")
+                .category(MenuCategory.COFFEE)
+                .price(3000)
+                .build();
+        List<BrandMenu> menus = List.of(menu1,menu2,menu3);
+        Brand brand = Brand.builder()
+                .name("컴포즈")
+                .build();
+        brand.addMenu(menu1);
+        brand.addMenu(menu2);
+        brand.addMenu(menu3);
+
+        Cafe cafe = Cafe.builder()
+                .name("컴포즈")
+                .address("창원시")
+                .longitude(123.0)
+                .latitude(123.0)
+                .brand(brand)
+                .build();
+
+        Map<String, List<MenuResponse>> menuResponse = menus.stream()
+                .map(MenuResponse::fromEntity)
+                .sorted(Comparator.comparing(MenuResponse::getPrice))
+                .collect(Collectors.groupingBy(MenuResponse::getCategory));
+
+        List<CafeDetailResponse> cafeDetailResponses = menuResponse.entrySet()
+                .stream()
+                .map(entry -> new CafeDetailResponse(entry.getKey(), entry.getValue()))
+                .toList();
+
+        VotePageResponse response = VotePageResponse.builder()
+                .voteId(1L)
+                .voteName("점심커탐")
+                .brandId(brand.getId())
+                .brandName(brand.getName())
+                .cafeDetailResponse(cafeDetailResponses)
+                .build();
+        
+        given(voteService.getVote(any(String.class)))
+                .willReturn(response);
+
+        String voterUuid = "voterUuid";
+        VoterPrincipal principal = VoterPrincipal.builder()
+                .voterUuid(voterUuid)
+                .voterName("김참여")
+                .voterType(VoterType.INVITED)
+                .build();
+        VoterAuthenticationToken authenticationToken = new VoterAuthenticationToken(principal,principal.getAuthorities());
+        given(voterAuthenticationProvider.authenticate(any(VoterAuthenticationToken.class)))
+                .willReturn(authenticationToken);
+        //when
+        mockMvc.perform(get("/votes/"+shareUuid)
+                        .header("Voter-UUID",voterUuid))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.voteId").value(response.getVoteId()))
+                .andExpect(jsonPath("$.brandId").value(response.getBrandId()))
+                .andExpect(jsonPath("$.brandName").value(response.getBrandName()))
+                .andExpect(jsonPath("$.cafeDetailResponse").isArray())
+                .andExpect(jsonPath("$.cafeDetailResponse", hasSize(greaterThan(0))))
+                .andExpect(jsonPath("$.cafeDetailResponse[0].category").exists())
+                .andExpect(jsonPath("$.cafeDetailResponse[0].menus[0]").exists());
+        //then
+
     }
 }

--- a/backend/src/test/java/com/keotam/vote/service/VoteServiceTest.java
+++ b/backend/src/test/java/com/keotam/vote/service/VoteServiceTest.java
@@ -7,6 +7,7 @@ import com.keotam.cafe.domain.MenuCategory;
 import com.keotam.cafe.domain.repository.CafeRepository;
 import com.keotam.global.service.PasswordEncryptor;
 import com.keotam.vote.domain.Vote;
+import com.keotam.vote.domain.VoteStatus;
 import com.keotam.vote.domain.Voter;
 import com.keotam.vote.domain.VoterType;
 import com.keotam.vote.domain.repository.VoteRepository;
@@ -169,5 +170,61 @@ class VoteServiceTest {
         assertEquals(result.getCafeDetailResponse().get(0).getCategory(),MenuCategory.COFFEE.toString());
         assertEquals(result.getCafeDetailResponse().get(0).getMenus().get(0).getName(),"아메리카노");
         assertEquals(result.getCafeDetailResponse().get(0).getMenus().get(0).getPrice(),2000);
+    }
+
+    @Test
+    @DisplayName("투표 페이지를 조회하면 투표를 위한 카페 정보를 포함한 투표 페이지를 반환한다.")
+    void whenGetVotePageSuccess() throws Exception {
+        //given
+        BrandMenu menu1 = BrandMenu.builder()
+                .name("아메리카노")
+                .category(MenuCategory.COFFEE)
+                .price(2000)
+                .build();
+        BrandMenu menu2 = BrandMenu.builder()
+                .name("말차라떼")
+                .category(MenuCategory.NON_COFFEE)
+                .price(5000)
+                .build();
+        BrandMenu menu3 = BrandMenu.builder()
+                .name("카페라떼")
+                .category(MenuCategory.COFFEE)
+                .price(3000)
+                .build();
+
+        Brand brand = Brand.builder()
+                .name("컴포즈")
+                .build();
+        brand.addMenu(menu1);
+        brand.addMenu(menu2);
+        brand.addMenu(menu3);
+
+        Cafe cafe = Cafe.builder()
+                .name("컴포즈")
+                .address("창원시")
+                .longitude(123.0)
+                .latitude(123.0)
+                .brand(brand)
+                .build();
+
+        Vote vote = Vote.builder()
+                .id(1L)
+                .voteName("점심커탐")
+                .cafe(cafe)
+                .shareUuid("shareUuid")
+                .adminUuid("adminUuid")
+                .status(VoteStatus.IN_PROGRESS)
+                .build();
+        String shareUuid = "shareUuid";
+        when(voteRepository.findByShareUuid(shareUuid))
+                .thenReturn(Optional.of(vote));
+        //when
+        VotePageResponse votePageResponse = voteService.getVote(shareUuid);
+        //then
+        assertEquals(votePageResponse.getVoteId(), 1L);
+        assertEquals(votePageResponse.getVoteName(),"점심커탐");
+        assertEquals(votePageResponse.getBrandId(),brand.getId());
+        assertEquals(votePageResponse.getBrandName(),brand.getName());
+        assertEquals(votePageResponse.getCafeDetailResponse().get(0).getCategory(),MenuCategory.COFFEE.toString());
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#13 
## 🪐 작업 내용
- [ ] 사용자 voter- uuid 기반 인증 필터체인 추가
- [ ] 사용자 재투표를 위한 페이지 조회 기능 구현

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
